### PR TITLE
Mobilefuse: Set adapter name in MobileFuse SDK

### DIFF
--- a/Adapters/MobileFuse/ISMobileFuseAdapter/ISMobileFuseAdapter.m
+++ b/Adapters/MobileFuse/ISMobileFuseAdapter/ISMobileFuseAdapter.m
@@ -29,6 +29,8 @@ static BOOL coppaValue = NO;
 static BOOL doNotTrackValue = NO;
 static NSString *doNotSellValue = @"1-";
 
+static NSString * const adapterName = @"unity_bidding";
+
 @interface ISMobileFuseAdapter() <IMFInitializationCallbackReceiver, ISNetworkInitCallbackProtocol>
 
 @end
@@ -87,6 +89,9 @@ static NSString *doNotSellValue = @"1-";
     dispatch_once(&initSdkOnceToken, ^{
         LogAdapterApi_Internal(@"placementId = %@", placementId);
         initState = INIT_STATE_IN_PROGRESS;
+        if ([MobileFuseSettings respondsToSelector:@selector(setSdkAdapter:)]) {
+            [MobileFuseSettings setSdkAdapter:adapterName];
+        }
         if ([ISConfigurations getConfigurations].adaptersDebug) {
             [MobileFuse enableVerboseLogging];
         }


### PR DESCRIPTION
### Description
Adds a setSdkAdapter() call during MobileFuse SDK initialization (iOS) so telemetry and Sentry reports correctly identify which adapter is being used.

### Changes

- Added an adapterName constant with value "unity_bidding"
- Added a guarded call to MobileFuseSettings.setSdkAdapter(adapterName) in initSDKWithPlacementId() (only if the selector is available)

### Motivation
Without setting the SDK adapter name, telemetry and error tracking systems may not attribute events to the correct adapter, which makes monitoring and debugging adapter-specific issues harder.